### PR TITLE
Fixes for YouTube mixes

### DIFF
--- a/rowsfix.user.css
+++ b/rowsfix.user.css
@@ -39,7 +39,7 @@ exec() {
         max-height: 3.6rem;
     }
 
-    #video-title.ytd-rich-grid-media {
+    #video-title.ytd-rich-grid-media, .yt-core-attributed-string--white-space-pre-wrap {
         font-size: 1.4rem;
         line-height: 2rem;
         max-height: 4rem;

--- a/rowsfix.user.css
+++ b/rowsfix.user.css
@@ -60,6 +60,10 @@ exec() {
     .ytd-two-column-browse-results-renderer {
         padding-inline: 6px;
     }
+    
+    .yt-thumbnail-view-model__image {
+            background: #000;
+    }
 
     if thumbs {
         ytd-two-column-browse-results-renderer.style-scope {
@@ -72,7 +76,7 @@ exec() {
     }
 
     if thumbradius {
-        ytd-thumbnail[size="large"] a.ytd-thumbnail, ytd-thumbnail[size="large"]::before {
+        ytd-thumbnail[size="large"] a.ytd-thumbnail, ytd-thumbnail[size="large"]::before, .yt-thumbnail-view-model--large, .collections-stack-wiz__collection-stack1--large, .collections-stack-wiz__collection-stack2 {
             border-radius: -radius;
         }
     }

--- a/rowsfix.user.css
+++ b/rowsfix.user.css
@@ -62,7 +62,7 @@ exec() {
     }
     
     .yt-thumbnail-view-model__image {
-            background: #000;
+        background: #000;
     }
 
     if thumbs {

--- a/rowsfix.user.css
+++ b/rowsfix.user.css
@@ -39,7 +39,7 @@ exec() {
         max-height: 3.6rem;
     }
 
-    #video-title.ytd-rich-grid-media, .yt-core-attributed-string--white-space-pre-wrap {
+    #video-title.ytd-rich-grid-media, .yt-lockup-metadata-view-model-wiz__title > span {
         font-size: 1.4rem;
         line-height: 2rem;
         max-height: 4rem;


### PR DESCRIPTION
Fixes for YouTube mixes:

- Mix title font size is now the same as other videos.
- Background colour for non-standard thumbnail sizes is now black instead of YouTube's default transparent.
- Mix thumbnails now follow custom border radius if enabled.